### PR TITLE
swap dragon name format

### DIFF
--- a/Resources/Locale/ru-RU/random-metadata/random-metadata-formats.ftl
+++ b/Resources/Locale/ru-RU/random-metadata/random-metadata-formats.ftl
@@ -6,7 +6,7 @@ name-format-regal-rat = { $part0 } { $part1 }
 name-format-revenant = { $part0 } { $part1 } { $part2 }
 name-format-ninja = { $part0 } { $part1 }
 name-format-wizard = { $part0 } { $part1 }
-name-format-dragon = { $part1 } { $part0 }
+name-format-dragon = { $part0 } { $part1 }
 # "<title> <name>"
 name-format-nukie-generic = { $part0 } { $part1 }
 name-format-nukie-agent = Агент { $part0 }


### PR DESCRIPTION
исправляет неправильный формат имени дракона
<img width="204" height="36" alt="Screenshot_20250801_000458" src="https://github.com/user-attachments/assets/bf3a0743-73a8-4299-b9dc-4cf489d432ff" />
